### PR TITLE
Link all images to one flex box

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -6,46 +6,49 @@ const Signup = () => {
     <main className="flex flex-col lg:px-2 xl:px-32 justify-between">
       <section className="hidden lg:flex flex-row justify-between items-center min-h-screen">
         <div className="hidden lg:block w-[638px] ">
-          <div className="flex flex-row gap-3 mb-3">
-            <Image
-              src="/landing4.jpg"
-              alt="photo"
-              width={200}
-              height={200}
-              className="w-1/2 h-[214px] rounded-xl"
-            />
-            <Image
-              src="/landing5.jpg"
-              alt="photo"
-              width={200}
-              height={200}
-              className="w-1/2 h-[214px] rounded-xl"
-            />
-          </div>
-          <div className="flex gap-3">
-            <Image
-              src="/landing1.jpg"
-              alt="photo"
-              width={200}
-              height={200}
-              className="w-[214px] h-[334px] rounded-xl"
-            />
-            <div>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-row gap-3">
               <Image
-                src="/landing6.jpg"
+                src="/landing4.jpg"
                 alt="photo"
                 width={200}
                 height={200}
-                className="w-[214px] h-[167px] rounded-xl"
+                className="w-1/2 h-[214px] rounded-xl"
               />
-              <div className="w-[214px] h-[167px] flex items-center justify-center">
-                <p className="text-xl font-bold xl:text-3xl">Create</p>
+              <Image
+                src="/landing5.jpg"
+                alt="photo"
+                width={200}
+                height={200}
+                className="w-1/2 h-[214px] rounded-xl"
+              />
+            </div>
+            <div className="flex gap-3">
+              <Image
+                src="/landing1.jpg"
+                alt="photo"
+                width={200}
+                height={200}
+                className="w-[214px] h-[334px] rounded-xl"
+              />
+              <div>
+                <Image
+                  src="/landing6.jpg"
+                  alt="photo"
+                  width={200}
+                  height={200}
+                  className="w-[214px] h-[167px] rounded-xl"
+                />
+                <div className="w-[214px] h-[167px] flex items-center justify-center">
+                  <p className="text-xl font-bold xl:text-3xl">Create</p>
+                </div>
               </div>
-            </div>
-            <div className="w-[214px] h-[167px] flex items-center justify-center">
-              <p className="text-xl font-bold xl:text-3xl">Explore</p>
-            </div>
+              <div className="w-[214px] h-[167px] flex items-center justify-center">
+                <p className="text-xl font-bold xl:text-3xl">Explore</p>
+              </div>
+            </div>       
           </div>
+
         </div>
         <div className="w-1/3">
           <p className="text-center text-xl font-bold xl:text-3xl">


### PR DESCRIPTION
Unable to make the landing page images using a grid because top two images don't span to whole columns. They span precisely 1.5 columns.

Docs on Grid here: https://tailwindcss.com/docs/grid-column.

If we would like to use grid we will have to change the image layout or consider adding more photos.

However I did combine the images to one div instead of having two divs

#21 